### PR TITLE
Add customer service pages and footer links

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -49,6 +49,11 @@ import AdminDashboard from "@/pages/admin/Dashboard";
 import AdminLogin from "@/pages/admin/Login";
 import { AdminProducts } from "@/pages/AdminProducts";
 import AdditionalServices from "@/pages/AdditionalServices";
+import Faq from "@/pages/Faq";
+import Shipping from "@/pages/Shipping";
+import Returns from "@/pages/Returns";
+import Terms from "@/pages/Terms";
+import Privacy from "@/pages/Privacy";
 import SearchResults from "@/pages/SearchResults";
 import ProductSearchPage from "@/pages/ProductSearchPage";
 import ProductList from "@/pages/ProductList";
@@ -197,6 +202,12 @@ function Router() {
         <Route path="/reviews" component={ReviewsListPage} />
         <Route path="/design-service" component={DesignServiceProduct} />
         <Route path="/additional-services" component={AdditionalServices} />
+
+        <Route path="/faq" component={Faq} />
+        <Route path="/shipping" component={Shipping} />
+        <Route path="/returns" component={Returns} />
+        <Route path="/terms" component={Terms} />
+        <Route path="/privacy" component={Privacy} />
 
         {/* Seller routes */}
         <Route path="/seller">

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -99,29 +99,44 @@ export function Footer() {
             <h4 className="text-lg font-semibold mb-4">고객센터</h4>
             <ul className="space-y-3">
               <li>
-                <a href="#" className="text-gray-400 hover:text-white transition-colors">
+                <Link
+                  href="/faq"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
                   자주 묻는 질문
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#" className="text-gray-400 hover:text-white transition-colors">
+                <Link
+                  href="/shipping"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
                   배송 안내
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#" className="text-gray-400 hover:text-white transition-colors">
+                <Link
+                  href="/returns"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
                   반품/교환
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#" className="text-gray-400 hover:text-white transition-colors">
+                <Link
+                  href="/terms"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
                   이용약관
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#" className="text-gray-400 hover:text-white transition-colors">
+                <Link
+                  href="/privacy"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
                   개인정보처리방침
-                </a>
+                </Link>
               </li>
             </ul>
             

--- a/client/src/pages/Faq.tsx
+++ b/client/src/pages/Faq.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function Faq() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">자주 묻는 질문</h1>
+      <p>자주 묻는 질문 페이지입니다.</p>
+    </div>
+  );
+}

--- a/client/src/pages/Privacy.tsx
+++ b/client/src/pages/Privacy.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function Privacy() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">개인정보처리방침</h1>
+      <p>개인정보처리방침 페이지입니다.</p>
+    </div>
+  );
+}

--- a/client/src/pages/Returns.tsx
+++ b/client/src/pages/Returns.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function Returns() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">반품/교환</h1>
+      <p>반품 및 교환 안내 페이지입니다.</p>
+    </div>
+  );
+}

--- a/client/src/pages/Shipping.tsx
+++ b/client/src/pages/Shipping.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function Shipping() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">배송 안내</h1>
+      <p>배송 안내 페이지입니다.</p>
+    </div>
+  );
+}

--- a/client/src/pages/Terms.tsx
+++ b/client/src/pages/Terms.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function Terms() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">이용약관</h1>
+      <p>서비스 이용약관 페이지입니다.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create FAQ, shipping, returns, terms, and privacy pages
- wire up routes to new pages
- link customer service footer items to real routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Declaration or statement expected in MyPage.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890aed15dbc8326ae4abb0d259aae42