### PR TITLE
Ensure nickname saved at signup and checked before commenting

### DIFF
--- a/client/src/components/CommentSection.tsx
+++ b/client/src/components/CommentSection.tsx
@@ -6,6 +6,8 @@ import { Separator } from '@/components/ui/separator'
 import { MessageSquare, User, Send, Edit2, Trash2, Save, X } from 'lucide-react'
 import { Link } from 'wouter'
 import { useSupabaseAuth } from '@/components/SupabaseProvider'
+import { useAuth } from '@/contexts/AuthContext'
+import { NicknameSetupDialog } from '@/components/NicknameSetupDialog'
 import { 
   usePostComments, 
   useCreatePostComment, 
@@ -61,7 +63,7 @@ const CommentItem: React.FC<CommentItemProps> = ({
       <div className="flex-1 min-w-0">
         <div className="flex items-center space-x-2 mb-1">
           <span className="font-medium text-white text-sm">
-            {comment.users?.username || comment.users?.email || '익명'}
+            {comment.users?.nickname || comment.users?.username || comment.users?.email || '익명'}
           </span>
           <span className="text-xs text-gray-400">
             {formatPostDate(comment.created_at)}
@@ -129,6 +131,7 @@ const CommentItem: React.FC<CommentItemProps> = ({
 
 export const CommentSection: React.FC<CommentSectionProps> = ({ postId, commentsCount = 0 }) => {
   const { user } = useSupabaseAuth()
+  const { user: authUser } = useAuth()
   const { data: comments, isLoading, error } = usePostComments(postId)
   const createComment = useCreatePostComment()
   const updateComment = useUpdatePostComment()
@@ -137,11 +140,17 @@ export const CommentSection: React.FC<CommentSectionProps> = ({ postId, comments
   const [commentContent, setCommentContent] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null)
+  const [showNicknameDialog, setShowNicknameDialog] = useState(false)
 
   const handleSubmitComment = async (e: React.FormEvent) => {
     e.preventDefault()
     
     if (!user || !commentContent.trim()) {
+      return
+    }
+
+    if (!authUser?.nickname) {
+      setShowNicknameDialog(true)
       return
     }
 
@@ -184,6 +193,7 @@ export const CommentSection: React.FC<CommentSectionProps> = ({ postId, comments
   const actualCommentsCount = comments?.length || commentsCount
 
   return (
+    <>
     <Card className="bg-[#1a1a1a] border-gray-700">
       <CardHeader>
         <CardTitle className="text-white flex items-center">
@@ -292,6 +302,12 @@ export const CommentSection: React.FC<CommentSectionProps> = ({ postId, comments
         )}
       </CardContent>
     </Card>
+    <NicknameSetupDialog
+      open={showNicknameDialog}
+      onOpenChange={setShowNicknameDialog}
+      onSuccess={() => setShowNicknameDialog(false)}
+    />
+    </>
   )
 }
 

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -121,7 +121,7 @@ export const Header = () => {
 
   const getDisplayName = () => {
     if (localUser) {
-      return localUser.username || localUser.email?.split("@")[0] || "사용자";
+      return localUser.nickname || localUser.username || localUser.email?.split("@")[0] || "사용자";
     }
     return "사용자";
   };

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -12,6 +12,7 @@ interface User {
   name: string;
   username?: string;
   email: string;
+  nickname?: string;
   points: number;
   coupons: number;
   totalOrders: number;
@@ -89,6 +90,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           name: data.first_name && data.last_name ? `${data.first_name} ${data.last_name}` : data.username,
           username: data.username,
           email: data.email,
+          nickname: data.nickname,
           points: 0,
           coupons: 0,
           totalOrders: 0,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -934,8 +934,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         if (existingUser.username === username) message += "아이디입니다.";
         else if (existingUser.email === email) message += "이메일입니다.";
         else if (existingUser.nickname === nickname) message += "닉네임입니다.";
-        
-        return res.status(400).json({ message });
+
+        return res.status(409).json({ message });
       }
 
       // Hash password with bcrypt
@@ -2031,7 +2031,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       if (existingNickname) {
-        return res.status(400).json({ message: "이미 사용 중인 닉네임입니다." });
+        return res.status(409).json({ message: "이미 사용 중인 닉네임입니다." });
       }
 
       // Update nickname using the validated target user ID

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -18,7 +18,7 @@ export const users = mysqlTable("users", {
   username: varchar("username", { length: 255 }).notNull().unique(),
   email: varchar("email", { length: 255 }).notNull().unique(),
   password: varchar("password", { length: 255 }).notNull(),
-  nickname: varchar("nickname", { length: 30 }),
+  nickname: varchar("nickname", { length: 30 }).notNull().unique(),
   firstName: varchar("first_name", { length: 255 }),
   lastName: varchar("last_name", { length: 255 }),
   phone: varchar("phone", { length: 20 }),


### PR DESCRIPTION
## Summary
- make `users.nickname` required and unique
- return 409 when nickname conflicts during registration or update
- store nickname in auth context and show nickname in header
- precheck nickname in comments and open setup dialog only if missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: client/src/pages/MyPage.tsx(963,1): error TS1128: Declaration or statement expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68960dc0a32883269995622945e90fb5