### PR TITLE
Validate Supabase environment variables

### DIFF
--- a/server/db/supabase.ts
+++ b/server/db/supabase.ts
@@ -1,6 +1,28 @@
+import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 
-const url = process.env.SUPABASE_URL!;
-const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const url = process.env.SUPABASE_URL;
+// NOTE: Service role key is for server-side use only. Never expose this to client code.
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url) {
+  console.error('SUPABASE_URL environment variable is missing.');
+  process.exit(1);
+}
+
+if (!/^https:\/\/[\w.-]+\.supabase\.co$/.test(url)) {
+  console.error('Invalid SUPABASE_URL format. Expected https://<project>.supabase.co');
+  process.exit(1);
+}
+
+if (!key) {
+  console.error('SUPABASE_SERVICE_ROLE_KEY environment variable is missing.');
+  process.exit(1);
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  console.log(`SUPABASE_URL: ${url.slice(0, 30)}...`);
+  console.log(`SUPABASE_SERVICE_ROLE_KEY: ${key.slice(0, 6)}...`);
+}
 
 export const sb = createClient(url, key, { auth: { persistSession: false } });


### PR DESCRIPTION
## Summary
- ensure .env is loaded first and validate SUPABASE_URL format
- log masked Supabase credentials only outside production

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689886dbf79c832681ea800d3c2e17fb