### PR TITLE
chore: add internal env loader

### DIFF
--- a/server/db/supabase.ts
+++ b/server/db/supabase.ts
@@ -1,4 +1,4 @@
-import 'dotenv/config';
+import '../lib/loadEnv';
 import { createClient } from '@supabase/supabase-js';
 
 const url = process.env.SUPABASE_URL;

--- a/server/lib/loadEnv.ts
+++ b/server/lib/loadEnv.ts
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Basic `.env` loader to avoid external dependency on `dotenv`.
+ * Loads key-value pairs into `process.env` if they are not already set.
+ */
+export function loadEnv(file: string = '.env') {
+  const envPath = path.resolve(process.cwd(), file);
+  if (!fs.existsSync(envPath)) return;
+
+  const contents = fs.readFileSync(envPath, 'utf8');
+  for (const line of contents.split('\n')) {
+    const match = line.match(/^\s*([A-Za-z0-9_\.\-]+)\s*=\s*(.*)?\s*$/);
+    if (!match) continue;
+    const key = match[1];
+    let value = match[2] ?? '';
+    // Remove surrounding quotes
+    value = value.replace(/(^['"]|['"]$)/g, '').trim();
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+// Automatically load environment variables on import
+loadEnv();


### PR DESCRIPTION
## Summary
- replace `dotenv` import with internal env loader
- add lightweight `.env` parser to server lib

## Testing
- `npm run check` *(fails: TS errors)*
- `npm run dev` *(fails: Cannot find module '/workspace/pinto/server/routes/storage')*

------
https://chatgpt.com/codex/tasks/task_e_6898901fc54c83269b75b72e0e41ee90