### PR TITLE
Add missing home page API routes

### DIFF
--- a/app/api/community/highlight/route.ts
+++ b/app/api/community/highlight/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sb } from '../../../../server/db/supabase';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const limit = Math.min(
+    Math.max(parseInt(searchParams.get('limit') || '4', 10) || 4, 1),
+    12,
+  );
+  console.log('[GET /api/community/highlight]', { url: req.url, limit });
+  try {
+    console.debug('Query community posts', { limit });
+    const { data: posts, error: pErr } = await sb
+      .from('community_posts')
+      .select('id, title, author_masked, image_url, created_at, is_featured')
+      .order('is_featured', { ascending: false })
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (pErr) throw pErr;
+
+    const postIds = (posts ?? []).map(p => p.id);
+    console.debug('Query community counts', { postIds });
+    const { data: counts, error: cErr } = await sb
+      .from('v_community_counts')
+      .select('post_id, likes, comments')
+      .in('post_id', postIds);
+    if (cErr) throw cErr;
+
+    const countMap = new Map((counts ?? []).map(c => [c.post_id, c]));
+    const payload = (posts ?? []).map(p => {
+      const cnt = countMap.get(p.id);
+      return {
+        id: p.id,
+        image: p.image_url ?? '/api/placeholder/360/280',
+        title: p.title ?? '제목 없음',
+        likes: Number(cnt?.likes ?? 0),
+        comments: Number(cnt?.comments ?? 0),
+        tags: [] as string[],
+        author: p.author_masked ?? '사용자***',
+      };
+    });
+
+    console.log('[GET /api/community/highlight] result', { rowCount: payload.length });
+    return NextResponse.json(payload);
+  } catch (e: any) {
+    console.error('[GET /api/community/highlight] failed', e);
+    return NextResponse.json({ error: e.message || 'Unknown error' }, { status: 500 });
+  }
+}

--- a/app/api/recommendations/materials/route.ts
+++ b/app/api/recommendations/materials/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sb } from '../../../../server/db/supabase';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const limit = Math.min(
+    Math.max(parseInt(searchParams.get('limit') || '4', 10) || 4, 1),
+    12,
+  );
+  console.log('[GET /api/recommendations/materials]', { url: req.url, limit });
+  try {
+    console.debug('Query products for materials');
+    const { data: prods, error: pErr } = await sb
+      .from('products')
+      .select('id, name, name_ko, thumbnail_url, material, price, created_at, is_published')
+      .eq('is_published', true)
+      .order('created_at', { ascending: false })
+      .limit(32);
+    if (pErr) throw pErr;
+
+    const ids = (prods ?? []).map(p => p.id);
+    console.debug('Query review counts', { ids });
+    const { data: counts, error: cErr } = await sb
+      .from('v_product_review_counts')
+      .select('product_id, review_count, avg_rating')
+      .in('product_id', ids);
+    if (cErr) throw cErr;
+
+    const countMap = new Map((counts ?? []).map(c => [c.product_id, c]));
+    const ranked = (prods ?? [])
+      .map(p => {
+        const cnt = countMap.get(p.id);
+        const reviewCount = Number(cnt?.review_count ?? 0);
+        const avg = Number(cnt?.avg_rating ?? 0);
+        const badge = reviewCount > 200 ? 'HIT' : avg >= 4.5 ? '추천' : 'NEW';
+        const discount = badge === 'HIT' ? 20 : 0;
+        return {
+          id: p.id,
+          image: p.thumbnail_url ?? '/api/placeholder/360/280',
+          title: p.name_ko ?? p.name ?? '상품명',
+          price: Number(p.price ?? 0),
+          originalPrice: discount > 0 ? Math.round(Number(p.price) * 1.25) : null,
+          reviewCount,
+          badge,
+          material: p.material ?? '',
+          discount,
+        };
+      })
+      .sort((a, b) => (b.reviewCount - a.reviewCount) || (b.discount - a.discount))
+      .slice(0, limit);
+
+    console.log('[GET /api/recommendations/materials] result', { rowCount: ranked.length });
+    return NextResponse.json(ranked);
+  } catch (e: any) {
+    console.error('[GET /api/recommendations/materials] failed', e);
+    return NextResponse.json({ error: e.message || 'Unknown error' }, { status: 500 });
+  }
+}

--- a/app/api/reviews/creator/route.ts
+++ b/app/api/reviews/creator/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sb } from '../../../../server/db/supabase';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const limit = Math.min(
+    Math.max(parseInt(searchParams.get('limit') || '4', 10) || 4, 1),
+    12,
+  );
+  console.log('[GET /api/reviews/creator]', { url: req.url, limit });
+  try {
+    console.debug('Query reviews', { limit });
+    const { data: reviews, error: rErr } = await sb
+      .from('reviews')
+      .select('id, product_id, user_name, rating, comment, created_at')
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (rErr) throw rErr;
+
+    const productIds = Array.from(new Set((reviews ?? []).map(r => r.product_id)));
+    console.debug('Query products', { productIds });
+    const { data: products, error: pErr } = await sb
+      .from('products')
+      .select('id, name, name_ko, thumbnail_url')
+      .in('id', productIds);
+    if (pErr) throw pErr;
+
+    console.debug('Query review counts', { productIds });
+    const { data: counts, error: cErr } = await sb
+      .from('v_product_review_counts')
+      .select('product_id, review_count')
+      .in('product_id', productIds);
+    if (cErr) throw cErr;
+
+    const productMap = new Map((products ?? []).map(p => [p.id, p]));
+    const countMap = new Map((counts ?? []).map(c => [c.product_id, c]));
+
+    const payload = (reviews ?? []).map(r => {
+      const p = productMap.get(r.product_id);
+      const cnt = countMap.get(r.product_id);
+      return {
+        id: r.id,
+        productImage: p?.thumbnail_url ?? '/api/placeholder/360/280',
+        productName: p?.name_ko ?? p?.name ?? '상품명 미상',
+        userName: r.user_name ?? '사용자***',
+        rating: r.rating ?? 0,
+        date: new Date(r.created_at).toISOString().slice(0,10).replaceAll('-','.'),
+        reviewCount: Number(cnt?.review_count ?? 0),
+        comment: r.comment ?? '',
+        tags: [] as string[],
+      };
+    });
+
+    console.log('[GET /api/reviews/creator] result', { rowCount: payload.length });
+    return NextResponse.json(payload);
+  } catch (e: any) {
+    console.error('[GET /api/reviews/creator] failed', e);
+    return NextResponse.json({ error: e.message || 'Unknown error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- implement `/api/reviews/creator` to serve creator review previews
- add `/api/community/highlight` for featured community posts
- add `/api/recommendations/materials` to return material recommendations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TS errors in server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689895e27f948326b60f090d8e6b4074