### PR TITLE
feat: add nickname duplication check API and input component

### DIFF
--- a/app/api/auth/check-nickname/route.ts
+++ b/app/api/auth/check-nickname/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sb } from '../../../../server/db/supabase';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const value = searchParams.get('value');
+
+  if (!value) {
+    return NextResponse.json(
+      { available: false, message: 'value required' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const { data, error } = await sb
+      .from('users')
+      .select('id')
+      .eq('nickname', value)
+      .maybeSingle();
+
+    if (error) throw error;
+
+    if (data) {
+      return NextResponse.json({ available: false, message: '이미 사용 중' });
+    }
+
+    return NextResponse.json({ available: true });
+  } catch (e) {
+    console.error('[GET /api/auth/check-nickname] error', e);
+    return NextResponse.json(
+      { available: false, message: 'server error' },
+      { status: 500 },
+    );
+  }
+}
+

--- a/app/components/NicknameInput.tsx
+++ b/app/components/NicknameInput.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEffect, useState, ChangeEvent } from 'react';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+type Status = 'idle' | 'checking' | 'available' | 'taken';
+
+export default function NicknameInput({ value, onChange }: Props) {
+  const [status, setStatus] = useState<Status>('idle');
+  const [message, setMessage] = useState('');
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.value;
+    const allowed = /^[a-zA-Z0-9._-가-힣]*$/;
+    if (allowed.test(next)) {
+      onChange(next);
+    }
+  };
+
+  useEffect(() => {
+    if (!value) {
+      setStatus('idle');
+      setMessage('');
+      return;
+    }
+
+    setStatus('checking');
+    const handler = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/auth/check-nickname?value=${encodeURIComponent(value)}`,
+        );
+        const data = await res.json();
+        if (res.ok && data.available) {
+          setStatus('available');
+          setMessage('사용 가능');
+        } else {
+          setStatus('taken');
+          setMessage(data.message || '이미 사용 중');
+        }
+      } catch (e) {
+        setStatus('taken');
+        setMessage('server error');
+      }
+    }, 400);
+
+    return () => clearTimeout(handler);
+  }, [value]);
+
+  const borderClass =
+    status === 'checking'
+      ? 'border-yellow-500'
+      : status === 'available'
+      ? 'border-green-500'
+      : status === 'taken'
+      ? 'border-red-500'
+      : 'border-gray-300';
+
+  return (
+    <div className="space-y-1">
+      <input
+        type="text"
+        value={value}
+        onChange={handleChange}
+        className={`border p-2 rounded w-full ${borderClass}`}
+      />
+      {status === 'checking' && (
+        <p className="text-sm text-gray-500">확인 중…</p>
+      )}
+      {status === 'available' && (
+        <p className="text-sm text-green-500">사용 가능</p>
+      )}
+      {status === 'taken' && (
+        <p className="text-sm text-red-500">{message || '이미 사용 중'}</p>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `/api/auth/check-nickname` route with Supabase lookup and error handling
- create NicknameInput component with debounced validation and status UI

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: Property 'returning' does not exist on type 'MySqlInsertBase...')

------
https://chatgpt.com/codex/tasks/task_e_68995d942f1c8326a6dfb2978cad71fa