### PR TITLE
Fix nickname availability API request

### DIFF
--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -117,13 +117,19 @@ export default function Register() {
     setNicknameStatus({ checking: true, available: null, message: "확인 중..." });
 
     try {
-      const response = await fetch(`/api/auth/check-nickname/${encodeURIComponent(nickname)}`);
+      const response = await fetch(
+        `/api/auth/check-nickname?value=${encodeURIComponent(nickname)}`
+      );
       const data = await response.json();
-      
+
+      if (!response.ok) {
+        throw new Error(data.message || "닉네임 확인 실패");
+      }
+
       setNicknameStatus({
         checking: false,
         available: data.available,
-        message: data.message
+        message: data.message,
       });
     } catch (error) {
       setNicknameStatus({


### PR DESCRIPTION
## Summary
- request nickname availability using query parameter to align with API
- add response status handling for nickname check

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68995fe60d308326a648ac375a91a1ec