### PR TITLE
feat: seed korotto products

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Supabase Configuration
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key # server-only
 
 # Database Configuration (for local development)
 DATABASE_URL=your_database_url

--- a/server/scripts/seedProducts.ts
+++ b/server/scripts/seedProducts.ts
@@ -1,22 +1,36 @@
 import { sb } from '../db/supabase';
 import { checkProductsTable } from '../db/diagnostics';
 
-const DATA = [
-  { nameKo: '투명 아크릴 키링', priceKrw: 1200, reviewCount: 11774, slug: 'clear-acrylic-keyring' },
-  { nameKo: '하프미러 아크릴 키링', priceKrw: 1700, reviewCount: 1321, slug: 'half-mirror-acrylic-keyring' },
-  { nameKo: '글리터 아크릴 키링', priceKrw: 1200, reviewCount: 1031, slug: 'glitter-acrylic-keyring' },
-  { nameKo: '유색·투명컬러 아스텔 키링', priceKrw: 1200, reviewCount: 6430, slug: 'colored-transparent-astel-keyring' },
-  { nameKo: '자개 아크릴키링', priceKrw: 1200, reviewCount: 793, slug: 'nacre-acrylic-keyring' },
-  { nameKo: '렌티큘러 키링', priceKrw: 1800, reviewCount: 358, slug: 'lenticular-keyring' },
-  { nameKo: '거울 아크릴 키링', priceKrw: 1700, reviewCount: 331, slug: 'mirror-acrylic-keyring' },
-  { nameKo: '홀로그램 아크릴 키링', priceKrw: 1700, reviewCount: 1008, slug: 'hologram-acrylic-keyring' },
-  { nameKo: '5T 하프미러 아크릴 키링', priceKrw: 1900, reviewCount: 286, slug: '5t-half-mirror-acrylic-keyring' },
-  { nameKo: '5T 투명 아크릴 키링', priceKrw: 1400, reviewCount: 569, slug: '5t-clear-acrylic-keyring' },
-  { nameKo: '뮤트컬러 아크릴 키링', priceKrw: 1200, reviewCount: 714, slug: 'mute-color-acrylic-keyring' },
-  { nameKo: '야광 아크릴 키링', priceKrw: 1300, reviewCount: 289, slug: 'glow-in-the-dark-acrylic-keyring' },
-  { nameKo: '스핀 아크릴 키링', priceKrw: 1300, reviewCount: 236, slug: 'spin-acrylic-keyring' },
-  { nameKo: '앞뒤도바 5T 아크릴 키링', priceKrw: 1800, reviewCount: 144, slug: 'both-sides-5t-acrylic-keyring' },
-  { nameKo: '파스텔 양면 아스텔 아크릴 키링', priceKrw: 1300, reviewCount: 317, slug: 'pastel-double-astel-acrylic-keyring' },
+type SeedItem = {
+  category: string;
+  subcategory: string;
+  nameKo: string;
+  priceKrw: number;
+  reviewCount: number;
+  slug: string;
+};
+
+const DATA: SeedItem[] = [
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '투명 아크릴 키링', priceKrw: 1200, reviewCount: 11774, slug: 'clear-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '하프미러 아크릴 키링', priceKrw: 1700, reviewCount: 1321, slug: 'half-mirror-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '글리터 아크릴 키링', priceKrw: 1200, reviewCount: 1031, slug: 'glitter-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '유색·투명컬러 아스텔 키링', priceKrw: 1200, reviewCount: 6430, slug: 'colored-transparent-astel-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '자개 아크릴키링', priceKrw: 1200, reviewCount: 793, slug: 'nacre-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '렌티큘러 키링', priceKrw: 1800, reviewCount: 358, slug: 'lenticular-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '거울 아크릴 키링', priceKrw: 1700, reviewCount: 331, slug: 'mirror-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '홀로그램 아크릴 키링', priceKrw: 1700, reviewCount: 1008, slug: 'hologram-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '5T 하프미러 아크릴 키링', priceKrw: 1900, reviewCount: 286, slug: '5t-half-mirror-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '5T 투명 아크릴 키링', priceKrw: 1400, reviewCount: 569, slug: '5t-clear-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '뮤트컬러 아크릴 키링', priceKrw: 1200, reviewCount: 714, slug: 'mute-color-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '야광 아크릴 키링', priceKrw: 1300, reviewCount: 289, slug: 'glow-in-the-dark-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '스핀 아크릴 키링', priceKrw: 1300, reviewCount: 236, slug: 'spin-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '앞뒤도바 5T 아크릴 키링', priceKrw: 1800, reviewCount: 144, slug: 'both-sides-5t-acrylic-keyring' },
+  { category: 'acrylic', subcategory: 'keyring', nameKo: '파스텔 양면 아스텔 아크릴 키링', priceKrw: 1300, reviewCount: 317, slug: 'pastel-double-astel-acrylic-keyring' },
+  // Korotto products
+  { category: 'acrylic', subcategory: 'korotto', nameKo: '자립형 두꺼운 아크릴 스탠드 코롯토 (8T/9T)', priceKrw: 1700, reviewCount: 0, slug: 'korotto-thick-stand-8t-9t' },
+  { category: 'acrylic', subcategory: 'korotto', nameKo: '뒤도바 코롯토 자립형 두꺼운 아크릴 스탠드 (10T)', priceKrw: 2300, reviewCount: 0, slug: 'korotto-backbar-thick-stand-10t' },
+  { category: 'acrylic', subcategory: 'korotto', nameKo: '아프로바 입체형 코롯토 자립형 두꺼운 아크릴 스탠드 (10T)', priceKrw: 2300, reviewCount: 0, slug: 'aprova-3d-korotto-thick-stand-10t' },
+  { category: 'acrylic', subcategory: 'korotto', nameKo: '렌티큘러 코롯토 두꺼운 아크릴스탠드 렌티코롯토', priceKrw: 2600, reviewCount: 0, slug: 'lenticular-korotto-thick-stand' },
 ];
 
 function slugToPascal(slug: string): string {
@@ -34,8 +48,8 @@ export async function seedProducts(): Promise<void> {
   }
 
   const rows = DATA.map((p) => ({
-    category: 'acrylic',
-    subcategory: 'keyring',
+    category: p.category,
+    subcategory: p.subcategory,
     name_ko: p.nameKo,
     name_en: slugToPascal(p.slug),
     slug: p.slug,

--- a/supabase_seed_acrylic_korotto.sql
+++ b/supabase_seed_acrylic_korotto.sql
@@ -1,0 +1,13 @@
+INSERT INTO public.products (category, subcategory, name_ko, name_en, slug, price_krw, review_count)
+VALUES
+  ('acrylic','korotto','자립형 두꺼운 아크릴 스탠드 코롯토 (8T/9T)','KorottoThickStand8t9t','korotto-thick-stand-8t-9t',1700,0),
+  ('acrylic','korotto','뒤도바 코롯토 자립형 두꺼운 아크릴 스탠드 (10T)','KorottoBackbarThickStand10t','korotto-backbar-thick-stand-10t',2300,0),
+  ('acrylic','korotto','아프로바 입체형 코롯토 자립형 두꺼운 아크릴 스탠드 (10T)','Aprova3dKorottoThickStand10t','aprova-3d-korotto-thick-stand-10t',2300,0),
+  ('acrylic','korotto','렌티큘러 코롯토 두꺼운 아크릴스탠드 렌티코롯토','LenticularKorottoThickStand','lenticular-korotto-thick-stand',2600,0)
+ON CONFLICT (slug) DO UPDATE SET
+  category = EXCLUDED.category,
+  subcategory = EXCLUDED.subcategory,
+  name_ko = EXCLUDED.name_ko,
+  name_en = EXCLUDED.name_en,
+  price_krw = EXCLUDED.price_krw,
+  review_count = EXCLUDED.review_count;


### PR DESCRIPTION
## Summary
- add server-only korotto product seed entries and SQL upsert script
- document service role key usage in env example

## Testing
- `npm run check` *(fails: Cannot find module 'next/link' and other TS errors)*
- `curl -sS "http://localhost:3000/api/products?category=acrylic&subcategory=korotto"` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_689be4cce3708326a15c6337ad81c397