### PR TITLE
populate acrylic keyring list and detail view

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import Products from "@/pages/Products";
 import ProductDetail from "@/pages/ProductDetail";
 import ProductDetailSupabase from "@/pages/ProductDetailSupabase";
 import CategoryPage from "@/pages/CategoryPage";
+import KeyringDetail from "@/pages/KeyringDetail";
 import Login from "@/pages/Login";
 import Register from "@/pages/Register";
 import FindId from "@/pages/FindId";
@@ -97,6 +98,10 @@ function Router() {
         <Route path="/search" component={ProductSearchPage} />
 
         {/* Category routes */}
+        <Route
+          path="/category/:category/:subcategory/:id"
+          component={KeyringDetail}
+        />
         <Route
           path="/category/:category/:subcategory"
           component={CategoryPage}

--- a/client/src/components/ProductCard.tsx
+++ b/client/src/components/ProductCard.tsx
@@ -79,8 +79,9 @@ export function ProductCard({
   const reviewCount = product.reviewsCount || product.reviewCount || 0;
   const likeCount = product.likesCount || product.likeCount || 0;
 
+  const link = (product as any).detailPath || `/product/${product.id}`;
   return (
-    <Link href={`/product/${product.id}`} className="block">
+    <Link href={link} className="block">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}

--- a/client/src/data/acrylicKeyrings.ts
+++ b/client/src/data/acrylicKeyrings.ts
@@ -1,0 +1,23 @@
+export interface KeyringProduct {
+  id: string;
+  name: string;
+  price: number;
+}
+
+export const acrylicKeyrings: KeyringProduct[] = [
+  { id: "1", name: "투명 아크릴 키링", price: 1200 },
+  { id: "2", name: "하프미러 아크릴 키링", price: 1700 },
+  { id: "3", name: "글리터 아크릴 키링", price: 1200 },
+  { id: "4", name: "유색·투명컬러 아스텔 키링", price: 1200 },
+  { id: "5", name: "자개 아크릴키링", price: 1200 },
+  { id: "6", name: "렌티큘러 키링", price: 1800 },
+  { id: "7", name: "거울 아크릴 키링", price: 1700 },
+  { id: "8", name: "홀로그램 아크릴 키링", price: 1700 },
+  { id: "9", name: "5T 하프미러 아크릴 키링", price: 1900 },
+  { id: "10", name: "5T 투명 아크릴 키링", price: 1400 },
+  { id: "11", name: "뮤트컬러 아크릴 키링", price: 1200 },
+  { id: "12", name: "야광 아크릴 키링", price: 1300 },
+  { id: "13", name: "스핀 아크릴 키링", price: 1300 },
+  { id: "14", name: "앞뒤도바 5T 아크릴 키링", price: 1800 },
+  { id: "15", name: "파스텔 양면 아스텔 아크릴 키링", price: 1300 },
+];

--- a/client/src/pages/CategoryPage.tsx
+++ b/client/src/pages/CategoryPage.tsx
@@ -7,6 +7,7 @@ import { ProductGrid } from "@/components/ProductGrid";
 import { Product } from "@/shared/schema";
 import { ChevronRight, Grid } from "lucide-react";
 import { motion } from "framer-motion";
+import { acrylicKeyrings } from "@/data/acrylicKeyrings";
 
 interface SubCategory {
   id: string;
@@ -20,9 +21,10 @@ const categoryData = {
     id: "acrylic",
     name: { ko: "아크릴굿즈", en: "Acrylic Goods", ja: "アクリルグッズ", zh: "亚克力商品" },
     subcategories: [
+      { id: "keyring", name: { ko: "키링", en: "Keyring", ja: "キーリング", zh: "钥匙扣" }, slug: "keyring", count: 15 },
       { id: "korotto", name: { ko: "코롯토", en: "Korotto", ja: "コロット", zh: "Korotto" }, slug: "korotto", count: 85 },
       { id: "holder", name: { ko: "포카홀더", en: "Card Holder", ja: "カードホルダー", zh: "卡片夹" }, slug: "holder", count: 78 },
-      { id: "shaker", name: { ko: "아크릴쉐이커", en: "Acrylic Shaker", ja: "アクリルシェーカー", zh: "亚크力摇摇杯" }, slug: "shaker", count: 52 }
+      { id: "shaker", name: { ko: "아크릴쉐이커", en: "Acrylic Shaker", ja: "アクリルシェーカー", zh: "亚克力摇摇杯" }, slug: "shaker", count: 52 }
     ]
   },
   wood: {
@@ -52,7 +54,7 @@ const categoryData = {
 };
 
 export default function CategoryPage() {
-  const { category, subcategory } = useParams();
+  const { category, subcategory, page } = useParams();
   const [, setLocation] = useLocation();
   const { language, t } = useLanguage();
   const queryClient = useQueryClient();
@@ -72,8 +74,25 @@ export default function CategoryPage() {
     }
   });
 
+  const keyringProducts = React.useMemo(() => {
+    return acrylicKeyrings.map((p) => ({
+      id: p.id,
+      name: p.name,
+      nameKo: p.name,
+      basePrice: p.price.toString(),
+      category: "acrylic",
+      subcategory: "keyring",
+      detailPath: `/category/acrylic/keyring/${p.id}`,
+      isActive: true,
+    }));
+  }, []);
+
   // Filter products based on category and subcategory fields only
   const products = React.useMemo(() => {
+    if (category === "acrylic" && subcategory === "keyring") {
+      return keyringProducts as unknown as Product[];
+    }
+
     if (!allProducts) return [];
 
     // 1) Normalize fields to camelCase and ensure presence
@@ -99,7 +118,7 @@ export default function CategoryPage() {
     }
 
     return list as Product[];
-  }, [allProducts, category, subcategory]);
+  }, [allProducts, category, subcategory, keyringProducts]);
 
   const handleTabClick = (subcat: SubCategory) => {
     setLocation(`/category/${category}/${subcat.slug}`);

--- a/client/src/pages/KeyringDetail.tsx
+++ b/client/src/pages/KeyringDetail.tsx
@@ -1,0 +1,21 @@
+import { useParams, Link } from "wouter";
+import { acrylicKeyrings } from "@/data/acrylicKeyrings";
+
+export default function KeyringDetail() {
+  const { id } = useParams<{ id: string }>();
+  const product = acrylicKeyrings.find((p) => p.id === id);
+
+  if (!product) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">상품을 찾을 수 없습니다</div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background dark:bg-[#1a1a1a] p-4">
+      <h1 className="text-2xl font-bold mb-4">{product.name}</h1>
+      <p className="mb-4">가격: {product.price} 원</p>
+      <Link href="/category/acrylic/keyring" className="text-blue-500 underline">목록으로</Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- list 15 acrylic keyring products with prices and static data
- render keyring detail pages under `/category/acrylic/keyring/:id`
- allow product cards to link to custom detail paths

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check` (fails: Property 'returning' does not exist on type 'MySqlInsertBase'...)


------
https://chatgpt.com/codex/tasks/task_e_689be874227883269105bc5f395960ad