### PR TITLE
fix: show keyring products

### DIFF
--- a/client/src/pages/CategoryPage.tsx
+++ b/client/src/pages/CategoryPage.tsx
@@ -63,16 +63,21 @@ export default function CategoryPage() {
   const activeTab = subcategory || "";
 
   const currentCategory = categoryData[category as keyof typeof categoryData];
-  
-  // Query for all products
+
+  const isKeyringCategory = category === "acrylic" && subcategory === "keyring";
+
+  // Query for all products. Skip network request when showing static keyring data
   const { data: allProducts, isLoading } = useQuery({
-    queryKey: ['/api/products'],
+    queryKey: ["/api/products"],
     queryFn: async () => {
-      const response = await fetch('/api/products');
-      if (!response.ok) throw new Error('Failed to fetch products');
+      const response = await fetch("/api/products");
+      if (!response.ok) throw new Error("Failed to fetch products");
       return await response.json();
-    }
+    },
+    enabled: !isKeyringCategory,
   });
+
+  const loading = isLoading && !isKeyringCategory;
 
   const keyringProducts = React.useMemo(() => {
     return acrylicKeyrings.map((p) => ({
@@ -230,7 +235,7 @@ export default function CategoryPage() {
 
       {/* Products Grid */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {isLoading ? (
+        {loading ? (
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
             {[...Array(8)].map((_, i) => (
               <div key={i} className="bg-white dark:bg-[#1a1a1a] rounded-lg shadow-sm p-4 animate-pulse">


### PR DESCRIPTION
## Summary
- skip product API fetch for acrylic keyring page and show static keyring list

## Testing
- `npm run check`
- `npm run build` *(fails: Could not resolve "./lib/openai", Could not resolve "./socialAuth")*


------
https://chatgpt.com/codex/tasks/task_e_689bec3e9a588326918e697608a01b05